### PR TITLE
🔧 file watch builds on windows

### DIFF
--- a/src/efsw/FileWatcherWin32.cpp
+++ b/src/efsw/FileWatcherWin32.cpp
@@ -164,9 +164,6 @@ void FileWatcherWin32::run()
 
 			while ( ( res = GetQueuedCompletionStatus( mIOCP, &numOfBytes, &compKey, &ov, INFINITE ) ) != FALSE )
 			{
-				if (numOfBytes == 0){
-				 	numOfBytes = 1;
-				}
 				if ( compKey != 0 && compKey == reinterpret_cast<ULONG_PTR>( this ) )
 				{
 					break;

--- a/src/efsw/FileWatcherWin32.cpp
+++ b/src/efsw/FileWatcherWin32.cpp
@@ -164,6 +164,9 @@ void FileWatcherWin32::run()
 
 			while ( ( res = GetQueuedCompletionStatus( mIOCP, &numOfBytes, &compKey, &ov, INFINITE ) ) != FALSE )
 			{
+				if (numOfBytes == 0){
+				 	numOfBytes = 1;
+				}
 				if ( compKey != 0 && compKey == reinterpret_cast<ULONG_PTR>( this ) )
 				{
 					break;

--- a/src/efsw/WatcherWin32.cpp
+++ b/src/efsw/WatcherWin32.cpp
@@ -9,7 +9,7 @@ namespace efsw
 /// Unpacks events and passes them to a user defined callback.
 void CALLBACK WatchCallback(DWORD dwNumberOfBytesTransfered, LPOVERLAPPED lpOverlapped)
 {
-	if (dwNumberOfBytesTransfered == 0 || NULL == lpOverlapped)
+	if (NULL == lpOverlapped)
 	{
 		return;
 	}
@@ -19,6 +19,17 @@ void CALLBACK WatchCallback(DWORD dwNumberOfBytesTransfered, LPOVERLAPPED lpOver
 	WatcherStructWin32 * tWatch = (WatcherStructWin32*) lpOverlapped;
 	WatcherWin32 * pWatch = tWatch->Watch;
 	size_t offset = 0;
+
+	/*
+	* If dwNumberOfBytesTransfered == 0, it means the buffer overflowed (too many changes between GetOverlappedResults calls). 
+	* Those events are lost, but at least we can refresh so subsequent changes are seen again.
+	*/
+
+	if (dwNumberOfBytesTransfered == 0 )
+	{
+		RefreshWatch(tWatch);
+		return;
+	}
 
 	do
 	{


### PR DESCRIPTION
This PR aims to correct the fact that on large directories with dependencies on windows, if large changes happens between the calls to read the IO Completion ports the watch is reinstalled with ReadDirectoryChangesW in RefreshWatch. 

It happens that this code was present in the past, but the addition of the iocp support lost the branch of reinstalling a watcher on many changes (when the buffer for file changes given to ReadDirectoryChangesW isn't enough to log all file changes) :
https://github.com/SpartanJ/efsw/commit/52c962917f3e73ba4a2c4383821b17415f35b03c#diff-5c194c1d10a471bec967c14dc208aee9869ae6b766341ef9c08253094dec8edbL20

Relates to https://github.com/nxxm/nxxm-src/issues/573

